### PR TITLE
Add 'View <class> source' link to custom tab menu.

### DIFF
--- a/frontend/android/src/main/res/values/strings.xml
+++ b/frontend/android/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
   <string name="clear_search_query">Clear search query</string>
   <string name="dismiss">Dismiss</string>
   <string name="view_source">View source</string>
+  <string name="view_class_source">View %s source</string>
   <string name="unknown_source">Unknown source location!</string>
 
   <plurals name="updating">


### PR DESCRIPTION
We include the class name since the user might navigate to other classes in the custom tab which would otherwise make the behavior of something named 'View source' unintuitive.

![screenshot_1516050922](https://user-images.githubusercontent.com/66577/34961938-83c867c2-fa0f-11e7-9d55-213afe5f3b44.png)

Closes #14