### PR TITLE
Query string is not part of Item class name, fix #13

### DIFF
--- a/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/ItemViewHolder.kt
+++ b/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/ItemViewHolder.kt
@@ -107,7 +107,9 @@ internal class ItemViewHolder(
 
     val className = SpannableString(item.class_())
     val start = item.class_().indexOf(query, ignoreCase = true)
-    className.setSpan(StyleSpan(BOLD), start, start + query.length, SPAN_INCLUSIVE_EXCLUSIVE)
+    if (start >= 0) {
+      className.setSpan(StyleSpan(BOLD), start, start + query.length, SPAN_INCLUSIVE_EXCLUSIVE)
+    }
 
     var dotIndex = item.class_().indexOf('.')
     while (dotIndex >= 0) {


### PR DESCRIPTION
Both `_` and `%` (maybe more) bring up a lot of results.
This behavior might be related to SQL FTS with `LIKE` operator?

Two solutions here:
- filter for such characters
- don't assume that the query must be part of the item class name

This commit uses the 2nd approach, and check for `indexOf` default return value in this case `-1`.