### PR TITLE
Map "junit" to "test-base" instead of "legacy-test"

### DIFF
--- a/references/src/main/kotlin/com/jakewharton/sdksearch/reference/SourceMapping.kt
+++ b/references/src/main/kotlin/com/jakewharton/sdksearch/reference/SourceMapping.kt
@@ -278,7 +278,7 @@ internal val SOURCE_MAP = mapOf(
     "javax.microedition" to BASE.path("opengl/java/"),
     "javax.xml" to LIBCORE.path("luni/src/main/java/"),
 
-    "junit" to BASE.path("legacy-test/src/"),
+    "junit" to BASE.path("test-base/src/"),
     "junit.runner" to BASE.path("test-runner/src/"),
     "junit.textui" to BASE.path("test-runner/src/"),
 


### PR DESCRIPTION
This works: [https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/**test-base**/src/junit/framework/Test.java](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/test-base/src/junit/framework/Test.java)

This doesn't work: [https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/**legacy-test**/src/junit/framework/Test.java](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/legacy-test/src/junit/framework/Test.java)