### PR TITLE
Upsert items into the DB to prevent RecyclerView flashes.

### DIFF
--- a/frontend/chrome-extension/src/main/kotlin/com/jakewharton/sdksearch/Main.kt
+++ b/frontend/chrome-extension/src/main/kotlin/com/jakewharton/sdksearch/Main.kt
@@ -58,8 +58,8 @@ fun main(vararg args: String) {
     launch {
       val items = service.list(url).await()
           .filter { it.type == "class" }
-          .map { Item.createForInsert(listing, it.label, it.link, it.deprecated) }
-      store.updateListing(listing, items)
+          .map { Item.createForInsert(it.label, it.link, it.deprecated) }
+      store.updateItems(items)
 
       println("Updated $listing with ${items.size} items")
     }

--- a/store/android/build.gradle
+++ b/store/android/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
   androidTestImplementation deps.android.test.runner
   androidTestImplementation deps.truth
+  androidTestImplementation deps.kotlin.coroutines.jdk
 }
 
 kotlin {

--- a/store/android/src/androidTest/java/com/jakewharton/sdksearch/store/ItemStoreTest.kt
+++ b/store/android/src/androidTest/java/com/jakewharton/sdksearch/store/ItemStoreTest.kt
@@ -3,6 +3,7 @@ package com.jakewharton.sdksearch.store
 import android.support.test.InstrumentationRegistry
 import io.reactivex.observers.TestObserver
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -15,11 +16,13 @@ class ItemStoreTest {
       .itemStore()
 
   @Test fun wildcards() {
-    itemStore.updateListing("dummy", listOf(
-        Item(1, "dummy", "com.example", "One%Two", false, "percent.html"),
-        Item(2, "dummy", "com.example", "One_Two", false, "underscore.html"),
-        Item(3, "dummy", "com.example", "One\\Two", false, "escape.html")
-    ))
+    runBlocking {
+      itemStore.updateItems(listOf(
+          Item(1, "com.example", "One%Two", false, "percent.html"),
+          Item(2, "com.example", "One_Two", false, "underscore.html"),
+          Item(3, "com.example", "One\\Two", false, "escape.html")
+      ))
+    }
 
     itemStore.queryItems("%")
         .test()

--- a/store/android/src/main/java/com/jakewharton/sdksearch/store/DbCallback.kt
+++ b/store/android/src/main/java/com/jakewharton/sdksearch/store/DbCallback.kt
@@ -3,7 +3,7 @@ package com.jakewharton.sdksearch.store
 import android.arch.persistence.db.SupportSQLiteDatabase
 import android.arch.persistence.db.SupportSQLiteOpenHelper
 
-private const val VERSION = 2
+private const val VERSION = 3
 
 internal class DbCallback : SupportSQLiteOpenHelper.Callback(VERSION) {
   override fun onCreate(db: SupportSQLiteDatabase) {
@@ -11,7 +11,7 @@ internal class DbCallback : SupportSQLiteOpenHelper.Callback(VERSION) {
   }
 
   override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
-    if (oldVersion < 2) {
+    if (oldVersion < 3) {
       db.execSQL("DROP TABLE item")
       onCreate(db)
     }

--- a/store/android/src/main/java/com/jakewharton/sdksearch/store/SqlItem.kt
+++ b/store/android/src/main/java/com/jakewharton/sdksearch/store/SqlItem.kt
@@ -5,15 +5,14 @@ import com.jakewharton.sdksearch.store.ItemModel.Factory
 // TODO https://github.com/square/sqldelight/issues/227
 internal class SqlItem(val item: Item) : ItemModel {
   override fun id() = item.id
-  override fun listing() = item.listing
   override fun packageName() = item.packageName
   override fun className() = item.className
   override fun deprecated() = item.deprecated
   override fun link() = item.link
 
   companion object {
-    val FACTORY: Factory<SqlItem> = Factory { id, listing, packageName, className, deprecated, link ->
-      SqlItem(Item(id, listing, packageName, className, deprecated, link))
+    val FACTORY: Factory<SqlItem> = Factory { id, packageName, className, deprecated, link ->
+      SqlItem(Item(id, packageName, className, deprecated, link))
     }
   }
 }

--- a/store/android/src/main/sqldelight/com/jakewharton/sdksearch/store/Item.sq
+++ b/store/android/src/main/sqldelight/com/jakewharton/sdksearch/store/Item.sq
@@ -2,20 +2,24 @@ import java.lang.Boolean;
 
 CREATE TABLE item(
   id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-  listing TEXT NOT NULL,
   packageName TEXT NOT NULL,
   className TEXT NOT NULL,
   deprecated INTEGER AS Boolean NOT NULL DEFAULT 0,
-  link TEXT NOT NULL
+  link TEXT NOT NULL,
+
+  UNIQUE (packageName, className)
 );
 
 insert_item:
-INSERT INTO item(listing, packageName, className, deprecated, link) VALUES (?, ?, ?, ?, ?)
+INSERT OR ABORT INTO item(packageName, className, deprecated, link) VALUES (?, ?, ?, ?)
 ;
 
-clear_listing:
-DELETE FROM item
-WHERE listing = ?
+update_item:
+UPDATE item
+SET deprecated = ?3,
+    link = ?4
+WHERE packageName = ?1
+  AND className = ?2
 ;
 
 count:

--- a/store/js/src/main/kotlin/com/jakewharton/sdksearch/store/ItemStore.kt
+++ b/store/js/src/main/kotlin/com/jakewharton/sdksearch/store/ItemStore.kt
@@ -1,6 +1,6 @@
 package com.jakewharton.sdksearch.store
 
 actual interface ItemStore {
-  actual suspend fun updateListing(listing: String, items: List<Item>)
+  actual suspend fun updateItems(items: List<Item>)
   suspend fun queryItems(term: String): List<Item>
 }

--- a/store/src/main/kotlin/com/jakewharton/sdksearch/store/Item.kt
+++ b/store/src/main/kotlin/com/jakewharton/sdksearch/store/Item.kt
@@ -2,7 +2,6 @@ package com.jakewharton.sdksearch.store
 
 data class Item(
   val id: Long,
-  val listing: String,
   val packageName: String,
   val className: String,
   val deprecated: Boolean,
@@ -11,14 +10,14 @@ data class Item(
   companion object {
     private val PACKAGE = "^([a-z0-9]+.)+".toRegex()
 
-    fun createForInsert(listing: String, fqcn: String, link: String, deprecated: Boolean): Item {
+    fun createForInsert(fqcn: String, link: String, deprecated: Boolean): Item {
       val range = PACKAGE.find(fqcn)?.range
       if (range == null) {
         throw IllegalArgumentException("FQCN '$fqcn' doesn't appear to be valid.")
       }
       val packageName = fqcn.substring(range.start, range.endInclusive)
       val className = fqcn.substring(range.endInclusive + 1)
-      return Item(-1, listing, packageName, className, deprecated, link)
+      return Item(-1, packageName, className, deprecated, link)
     }
   }
 }

--- a/store/src/main/kotlin/com/jakewharton/sdksearch/store/ItemStore.kt
+++ b/store/src/main/kotlin/com/jakewharton/sdksearch/store/ItemStore.kt
@@ -1,5 +1,5 @@
 package com.jakewharton.sdksearch.store
 
 expect interface ItemStore {
-  suspend fun updateListing(listing: String, items: List<Item>)
+  suspend fun updateItems(items: List<Item>)
 }

--- a/store/src/test/kotlin/com/jakewharton/sdksearch/store/ItemTest.kt
+++ b/store/src/test/kotlin/com/jakewharton/sdksearch/store/ItemTest.kt
@@ -5,11 +5,11 @@ import kotlin.test.assertEquals
 
 class ItemTest {
   @Test fun fqcnParsing() {
-    assertEquals(Item(-1, "", "com.example", "Example", false, ""),
-        Item.createForInsert("", "com.example.Example", "", false))
-    assertEquals(Item(-1, "", "com.example", "Example.Nested", false, ""),
-        Item.createForInsert("", "com.example.Example.Nested", "", false))
-    assertEquals(Item(-1, "", "com.example", "R.attr", false, ""),
-        Item.createForInsert("", "com.example.R.attr", "", false))
+    assertEquals(Item(-1, "com.example", "Example", false, ""),
+        Item.createForInsert("com.example.Example", "", false))
+    assertEquals(Item(-1, "com.example", "Example.Nested", false, ""),
+        Item.createForInsert("com.example.Example.Nested", "", false))
+    assertEquals(Item(-1, "com.example", "R.attr", false, ""),
+        Item.createForInsert("com.example.R.attr", "", false))
   }
 }

--- a/store/temp-jdk/src/main/kotlin/com/jakewharton/sdksearch/store/ItemStore.kt
+++ b/store/temp-jdk/src/main/kotlin/com/jakewharton/sdksearch/store/ItemStore.kt
@@ -4,6 +4,6 @@ import io.reactivex.Observable
 
 actual interface ItemStore {
   fun count(): Observable<Long>
-  actual suspend fun updateListing(listing: String, items: List<Item>)
+  actual suspend fun updateItems(items: List<Item>)
   fun queryItems(term: String): Observable<List<Item>>
 }

--- a/sync/src/main/java/com/jakewharton/sdksearch/sync/ItemSynchronizer.kt
+++ b/sync/src/main/java/com/jakewharton/sdksearch/sync/ItemSynchronizer.kt
@@ -69,10 +69,10 @@ class ItemSynchronizer(
 
     val items = apiItems
         .filter { it.type == "class" }
-        .map { Item.createForInsert(listing, it.label, it.link, it.deprecated) }
+        .map { Item.createForInsert(it.label, it.link, it.deprecated) }
 
     try {
-      itemStore.updateListing(listing, items)
+      itemStore.updateItems(items)
     } catch (e: RuntimeException) {
       Timber.i(e, "Unable to save $listing")
       loader.send(LoadResult(listing, false))


### PR DESCRIPTION
Previously the item would be assigned a new ID which would cause any displayed row to flash if updated in the background.

@AlecStrong