### PR TITLE
Use lambdas instead of object literals

### DIFF
--- a/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/util/TextViewExtensions.kt
+++ b/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/util/TextViewExtensions.kt
@@ -2,7 +2,6 @@ package com.jakewharton.sdksearch.search.ui.util
 
 import android.text.Editable
 import android.text.TextWatcher
-import android.view.KeyEvent
 import android.widget.TextView
 
 internal inline fun TextView.onTextChanged(crossinline body: (text: CharSequence) -> Unit): TextWatcher {
@@ -16,9 +15,5 @@ internal inline fun TextView.onTextChanged(crossinline body: (text: CharSequence
 }
 
 internal inline fun TextView.onEditorAction(crossinline body: (actionId: Int) -> Boolean) {
-  setOnEditorActionListener(object : TextView.OnEditorActionListener {
-    override fun onEditorAction(v: TextView, actionId: Int, event: KeyEvent?): Boolean {
-      return body(actionId)
-    }
-  })
+  setOnEditorActionListener { _, actionId, _ -> body(actionId) }
 }

--- a/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/util/ViewExtensions.kt
+++ b/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/util/ViewExtensions.kt
@@ -4,9 +4,5 @@ import android.view.KeyEvent
 import android.view.View
 
 internal inline fun View.onKey(crossinline body: (KeyEvent) -> Boolean) {
-  setOnKeyListener(object : View.OnKeyListener {
-    override fun onKey(v: View, keyCode: Int, event: KeyEvent): Boolean {
-      return body(event)
-    }
-  })
+  setOnKeyListener { _, _, event -> body(event) }
 }


### PR DESCRIPTION
@JakeWharton was this intentional?

There's not much difference in the generated bytecode.

Before:
```java
public final class ViewExtensionsKt {
   public static final void onKey(@NotNull View $receiver, @NotNull final Function1 body) {
      Intrinsics.checkParameterIsNotNull($receiver, "$receiver");
      Intrinsics.checkParameterIsNotNull(body, "body");
      $receiver.setOnKeyListener((OnKeyListener)(new OnKeyListener() {
         public boolean onKey(@NotNull View v, int keyCode, @NotNull KeyEvent event) {
            Intrinsics.checkParameterIsNotNull(v, "v");
            Intrinsics.checkParameterIsNotNull(event, "event");
            return ((Boolean)body.invoke(event)).booleanValue();
         }
      }));
   }
}
```

After:
```java
public final class ViewExtensionsKt {
   public static final void onKey(@NotNull View $receiver, @NotNull final Function1 body) {
      Intrinsics.checkParameterIsNotNull($receiver, "$receiver");
      Intrinsics.checkParameterIsNotNull(body, "body");
      $receiver.setOnKeyListener((OnKeyListener)(new OnKeyListener() {
         public final boolean onKey(View $noName_0, int $noName_1, KeyEvent event) {
            Function1 var10000 = body;
            Intrinsics.checkExpressionValueIsNotNull(event, "event");
            return ((Boolean)var10000.invoke(event)).booleanValue();
         }
      }));
   }
}
```