### PR TITLE
Add backward compability to Android SDK 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.buildConfig = [
       'compileSdk': 27,
-      'minSdk': 24,
+      'minSdk': 21,
       'targetSdk': 27,
 
       'version': [

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -105,6 +105,8 @@ dependencies {
 
   debugImplementation project(':debug-updater')
 
+  implementation deps.rx.relay
+
   implementation deps.kotlin.stdlib.jdk
   implementation deps.kotlin.coroutines.jdk
   implementation deps.kotlin.coroutines.android

--- a/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/MainActivity.kt
@@ -14,6 +14,7 @@ import com.jakewharton.sdksearch.search.ui.SearchViewBinder
 import dagger.Module
 import dagger.android.AndroidInjection
 import dagger.android.ContributesAndroidInjector
+import io.reactivex.functions.Consumer
 import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.Unconfined
 import kotlinx.coroutines.experimental.launch
@@ -55,7 +56,7 @@ class MainActivity : Activity() {
     } else null
 
     setContentView(R.layout.main)
-    val binder = SearchViewBinder(window.decorView, presenter.events, onClick, onCopy, onShare, onSource)
+    val binder = SearchViewBinder(window.decorView, Consumer<SearchPresenter.Event>() { presenter._events.accept(it) }, onClick, onCopy, onShare, onSource)
     defaultQuery?.let { binder.init(it) }
 
     binderJob = launch(Unconfined) {

--- a/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/MainActivity.kt
@@ -22,8 +22,10 @@ import timber.log.Timber
 import javax.inject.Inject
 
 class MainActivity : Activity() {
-  @Inject lateinit var presenter: SearchPresenter
-  @Inject lateinit var baseUrl: BaseUrl
+  @Inject
+  lateinit var presenter: SearchPresenter
+  @Inject
+  lateinit var baseUrl: BaseUrl
 
   private lateinit var presenterJob: Job
   private lateinit var binderJob: Job
@@ -56,7 +58,7 @@ class MainActivity : Activity() {
     } else null
 
     setContentView(R.layout.main)
-    val binder = SearchViewBinder(window.decorView, Consumer<SearchPresenter.Event>() { presenter._events.accept(it) }, onClick, onCopy, onShare, onSource)
+    val binder = SearchViewBinder(window.decorView, Consumer { presenter._events.accept(it) }, onClick, onCopy, onShare, onSource)
     defaultQuery?.let { binder.init(it) }
 
     binderJob = launch(Unconfined) {

--- a/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/OpenDocumentationItemHandler.kt
+++ b/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/OpenDocumentationItemHandler.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.support.customtabs.CustomTabsIntent
+import android.support.v4.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
 import com.jakewharton.sdksearch.R
@@ -13,15 +14,15 @@ import com.jakewharton.sdksearch.search.ui.ItemHandler
 import com.jakewharton.sdksearch.store.Item
 
 internal class OpenDocumentationItemHandler(
-  private val context: Context,
-  private val baseUrl: BaseUrl,
-  private val androidReference: AndroidReference
+    private val context: Context,
+    private val baseUrl: BaseUrl,
+    private val androidReference: AndroidReference
 ) : ItemHandler {
   override fun invoke(item: Item) {
     val uri = baseUrl.resolve(item.link).toUri()
     val sourceUri = androidReference.sourceUrl(item.packageName, item.className)?.toUri()
     CustomTabsIntent.Builder()
-        .setToolbarColor(context.getColor(R.color.green))
+        .setToolbarColor(ContextCompat.getColor(context, R.color.green))
         .addDefaultShareMenuItem()
         .apply {
           if (sourceUri != null) {

--- a/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/OpenSourceItemHandler.kt
+++ b/frontend/android/src/main/java/com/jakewharton/sdksearch/ui/OpenSourceItemHandler.kt
@@ -2,12 +2,13 @@ package com.jakewharton.sdksearch.ui
 
 import android.content.Context
 import android.support.customtabs.CustomTabsIntent
+import android.support.v4.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.widget.toast
 import com.jakewharton.sdksearch.R
-import com.jakewharton.sdksearch.store.Item
 import com.jakewharton.sdksearch.reference.AndroidReference
 import com.jakewharton.sdksearch.search.ui.ItemHandler
+import com.jakewharton.sdksearch.store.Item
 
 internal class OpenSourceItemHandler(
   private val context: Context,
@@ -17,7 +18,7 @@ internal class OpenSourceItemHandler(
     val url = androidReference.sourceUrl(item.packageName, item.className)
     if (url != null) {
       CustomTabsIntent.Builder()
-          .setToolbarColor(context.getColor(R.color.green))
+          .setToolbarColor(ContextCompat.getColor(context, R.color.green))
           .addDefaultShareMenuItem()
           .build()
           .launchUrl(context, url.toUri())

--- a/search/presenter/src/main/java/com/jakewharton/sdksearch/search/presenter/SearchPresenter.kt
+++ b/search/presenter/src/main/java/com/jakewharton/sdksearch/search/presenter/SearchPresenter.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.rx2.openSubscription
 import kotlinx.coroutines.experimental.selects.select
 import java.util.concurrent.TimeUnit
-import java.util.function.Consumer
 
 class SearchPresenter(
   private val context: CoroutineDispatcher,
@@ -24,8 +23,7 @@ class SearchPresenter(
   private val _models = ConflatedBroadcastChannel<Model>()
   val models: ReceiveChannel<Model> get() = _models.openSubscription()
 
-  private val _events = PublishRelay.create<Event>()
-  val events: Consumer<Event> get() = Consumer { _events.accept(it) }
+  val _events = PublishRelay.create<Event>()
 
   fun start(): Job {
     val itemCount = store.count().openSubscription()

--- a/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/ItemViewHolder.kt
+++ b/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/ItemViewHolder.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.sdksearch.search.ui
 
 import android.graphics.Typeface.BOLD
+import android.os.Build
 import android.support.v4.graphics.ColorUtils
 import android.support.v7.widget.RecyclerView.ViewHolder
 import android.text.style.ForegroundColorSpan
@@ -21,16 +22,21 @@ import com.jakewharton.sdksearch.store.Item
 import kotlin.LazyThreadSafetyMode.NONE
 
 internal class ItemViewHolder(
-  private val root: View,
-  private val callback: ItemAdapter.Callback
+    private val root: View,
+    private val callback: ItemAdapter.Callback
 ) : ViewHolder(root), OnClickListener, OnMenuItemClickListener {
   private val packageNameText: TextView = root.findViewById(R.id.package_name)
   private val classNameText: TextView = root.findViewById(R.id.class_name)
   private val overflow: View = root.findViewById(R.id.more_options)
 
   private val popup by lazy(NONE) {
-    val window = PopupMenu(root.context, overflow, Gravity.NO_GRAVITY,
-            0, android.R.style.Widget_Material_PopupMenu_Overflow)
+    val window = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      PopupMenu(root.context, overflow, Gravity.NO_GRAVITY,
+          0, android.R.style.Widget_Material_PopupMenu_Overflow)
+    } else {
+      PopupMenu(root.context, overflow, Gravity.NO_GRAVITY)
+    }
+
     overflow.setOnTouchListener(window.dragToOpenListener)
     window.menuInflater.inflate(R.menu.item, window.menu)
     window.setOnMenuItemClickListener(this)

--- a/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/SearchViewBinder.kt
+++ b/search/ui/src/main/java/com/jakewharton/sdksearch/search/ui/SearchViewBinder.kt
@@ -32,15 +32,14 @@ import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.channels.actor
 import kotlinx.coroutines.experimental.channels.consumeEach
 import kotlinx.coroutines.experimental.launch
-import java.util.function.Consumer
 
 class SearchViewBinder(
-  view: View,
-  private val events: Consumer<Event>,
-  private val onClick: ItemHandler,
-  private val onCopy: ItemHandler,
-  private val onShare: ItemHandler,
-  private val onSource: ItemHandler
+    view: View,
+    private val events: io.reactivex.functions.Consumer<Event>,
+    private val onClick: ItemHandler,
+    private val onCopy: ItemHandler,
+    private val onShare: ItemHandler,
+    private val onSource: ItemHandler
 ) {
   private val context = view.context
   private val resources = view.resources


### PR DESCRIPTION
Hi,
I found this app useful, but nowadays most of my devices have Android SDK lower that 24, that was personal reason to add this change.

I moved `Consumer<Event>` from one package to another as after downgrading `minSDKversion` in  file from `24` to `21`, I got `NoClassDefFoundError:com.jakewharton.sdksearch.search.presenter.SearchPresenter#events`. Also I didn't understand why there are two variables with similar name and the second one just for getter.

Hope that someone will find it useful.