### PR TITLE
Replace compile with implementation.

### DIFF
--- a/store/item/android/build.gradle
+++ b/store/item/android/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   implementation deps.kotlin.coroutines.jdk
   implementation deps.sqldelight.android
 
-  testCompile deps.kotlin.test.jdk
+  testImplementation deps.kotlin.test.jdk
 }
 
 kotlin {


### PR DESCRIPTION
To remove that pesky gradle warning.