### PR TITLE
[dagger-reflect] Error messages for @Inject private/static members

### DIFF
--- a/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
+++ b/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
@@ -43,10 +43,12 @@ final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
           continue;
         }
         if ((field.getModifiers() & Modifier.PRIVATE) != 0) {
-          throw new IllegalArgumentException(); // TODO report can't be private
+          throw new IllegalArgumentException("Dagger does not support injection into private fields: "
+                  + target.getCanonicalName() + "." + field.getName());
         }
         if ((field.getModifiers() & Modifier.STATIC) != 0) {
-          throw new IllegalArgumentException(); // TODO report can't be static
+          throw new IllegalArgumentException("Dagger does not support injection into static fields: "
+                  + target.getCanonicalName() + "." + field.getName());
         }
 
         Key key = Key.of(findQualifier(field.getDeclaredAnnotations()), field.getGenericType());
@@ -59,14 +61,17 @@ final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
           continue;
         }
         if ((method.getModifiers() & Modifier.PRIVATE) != 0) {
-          throw new IllegalArgumentException(); // TODO report can't be private
+          throw new IllegalArgumentException("Dagger does not support injection into private methods: "
+                  + target.getCanonicalName() + "." + method.getName() + "()");
         }
         if ((method.getModifiers() & Modifier.STATIC) != 0) {
-          throw new IllegalArgumentException(); // TODO report can't be static
+          throw new IllegalArgumentException("Dagger does not support injection into static methods: "
+                  + target.getCanonicalName() + "." + method.getName() + "()");
         }
 
         Type[] parameterTypes = method.getGenericParameterTypes();
         Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        @SuppressWarnings("rawtypes")
         Binding<?>[] bindings = new Binding[parameterTypes.length];
         for (int i = 0; i < parameterTypes.length; i++) {
           Key key = Key.of(findQualifier(parameterAnnotations[i]), parameterTypes[i]);

--- a/dagger-reflect/reflect/src/test/java/dagger/DaggerTest.java
+++ b/dagger-reflect/reflect/src/test/java/dagger/DaggerTest.java
@@ -23,7 +23,9 @@ import static org.junit.Assert.fail;
 
 public final class DaggerTest {
   @Component abstract static class AbstractClass {
-    @Component.Builder interface Builder {}
+    @Component.Builder interface Builder {
+      AbstractClass build();
+    }
   }
 
   @Test public void abstractClassCreateFails() {
@@ -49,7 +51,10 @@ public final class DaggerTest {
   }
 
   interface NoAnnotation {
-    @Component.Builder interface Builder {}
+    // [dagger-compiler] error: @Component.Builder types must be nested within a @Component
+    @Component.Builder interface Builder {
+      NoAnnotation build();
+    }
   }
 
   @Test public void noComponentAnnotationCreateFails() {
@@ -123,7 +128,9 @@ public final class DaggerTest {
   @Component
   interface PackagePrivateComponent {
     @Component.Builder
-    interface Builder {}
+    interface Builder {
+      PackagePrivateComponent build();
+    }
   }
 
   @Test public void packagePrivateComponentFails() {

--- a/dagger-reflect/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
+++ b/dagger-reflect/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
@@ -27,7 +27,8 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("ALL") // Unused fields/parameters and over-specified visibility for testing.
 public final class ReflectiveMembersInjectorTest {
   private static class PrivateField {
-    @Inject private String field;
+    // [dagger-compiler] error: Dagger does not support injection into private fields
+    @Inject private String privateField;
   }
 
   @Test public void privateFieldFails() {
@@ -36,12 +37,15 @@ public final class ReflectiveMembersInjectorTest {
       ReflectiveMembersInjector.create(PrivateField.class, graph);
       fail();
     } catch (IllegalArgumentException e) {
-      // TODO assert message
+      assertThat(e).hasMessageThat().startsWith("Dagger does not support injection into private fields");
+      assertThat(e).hasMessageThat().contains(PrivateField.class.getCanonicalName());
+      assertThat(e).hasMessageThat().contains("privateField");
     }
   }
 
   private static class StaticField {
-    @Inject static String field;
+    // [dagger-compiler] error: Dagger does not support injection into static fields
+    @Inject static String staticField;
   }
 
   @Test public void staticFieldFails() {
@@ -50,7 +54,9 @@ public final class ReflectiveMembersInjectorTest {
       ReflectiveMembersInjector.create(StaticField.class, graph);
       fail();
     } catch (IllegalArgumentException e) {
-      // TODO assert message
+      assertThat(e).hasMessageThat().startsWith("Dagger does not support injection into static fields");
+      assertThat(e).hasMessageThat().contains(StaticField.class.getCanonicalName());
+      assertThat(e).hasMessageThat().contains("staticField");
     }
   }
 
@@ -91,7 +97,8 @@ public final class ReflectiveMembersInjectorTest {
   }
 
   private static class PrivateMethod {
-    @Inject private void one(String one) {}
+    // [dagger-compiler] error: Dagger does not support injection into private methods
+    @Inject private void privateMethod(String one) {}
   }
 
   @Test public void privateMethodFails() {
@@ -100,12 +107,15 @@ public final class ReflectiveMembersInjectorTest {
       ReflectiveMembersInjector.create(PrivateMethod.class, graph);
       fail();
     } catch (IllegalArgumentException e) {
-      // TODO assert message
+      assertThat(e).hasMessageThat().startsWith("Dagger does not support injection into private methods");
+      assertThat(e).hasMessageThat().contains(PrivateMethod.class.getCanonicalName());
+      assertThat(e).hasMessageThat().contains("privateMethod()");
     }
   }
 
   private static class StaticMethod {
-    @Inject static void one(String one) {}
+    // [dagger-compiler] error: Dagger does not support injection into static methods
+    @Inject static void staticMethod(String one) {}
   }
 
   @Test public void staticMethodFails() {
@@ -114,7 +124,9 @@ public final class ReflectiveMembersInjectorTest {
       ReflectiveMembersInjector.create(StaticMethod.class, graph);
       fail();
     } catch (IllegalArgumentException e) {
-      // TODO assert message
+      assertThat(e).hasMessageThat().startsWith("Dagger does not support injection into static methods");
+      assertThat(e).hasMessageThat().contains(StaticMethod.class.getCanonicalName());
+      assertThat(e).hasMessageThat().contains("staticMethod()");
     }
   }
 


### PR DESCRIPTION
Wanted to mirror Dagger's messaging so I temporarily added `testAnnotationProcessor deps.dagger.compiler` in `:dagger-reflect:reflect` and did a compilation (hence the first commit making stuff well-formed to reduce noise).