### PR TITLE
[dagger-reflect] No bindings during injection is OK

### DIFF
--- a/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
+++ b/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
@@ -79,7 +79,6 @@ final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
       target = target.getSuperclass();
     }
 
-    // TODO what if both are empty?
     return new ReflectiveMembersInjector<>(fieldBindings, methodBindings);
   }
 

--- a/dagger-reflect/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
+++ b/dagger-reflect/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
@@ -75,6 +75,55 @@ public final class ReflectiveMembersInjectorTest {
     assertThat(instance.three).isEqualTo(3);
   }
 
+  private static class EmptyClass {}
+
+  @Test public void emptyInjection() {
+    BindingGraph graph = new BindingGraph.Builder().build();
+    MembersInjector<EmptyClass> injector =
+        ReflectiveMembersInjector.create(EmptyClass.class, graph);
+    EmptyClass instance = new EmptyClass();
+
+    injector.injectMembers(instance);
+
+    // no state, nothing to verify, except it didn't throw
+  }
+
+  private static class NoInjectsClass {
+    protected String one;
+    Long two;
+    public int three;
+
+    private int count = 0;
+    public void one(String one) {
+      count++;
+    }
+    Long two(Long two) {
+      count++;
+      return two;
+    }
+    private void three(int three) {
+      count++;
+    }
+  }
+
+  @Test public void noInjection() {
+    BindingGraph graph = new BindingGraph.Builder()
+        .add(Key.of(null, String.class), new Binding.Instance<>("one"))
+        .add(Key.of(null, Long.class), new Binding.Instance<>(2L))
+        .add(Key.of(null, int.class), new Binding.Instance<>(3))
+        .build();
+    MembersInjector<NoInjectsClass> injector =
+        ReflectiveMembersInjector.create(NoInjectsClass.class, graph);
+    NoInjectsClass instance = new NoInjectsClass();
+
+    injector.injectMembers(instance);
+
+    assertThat(instance.one).isEqualTo(null);
+    assertThat(instance.two).isEqualTo(null);
+    assertThat(instance.three).isEqualTo(0);
+    assertThat(instance.count).isEqualTo(0);
+  }
+
   private static class FieldQualifier {
     @Inject @Named("tres") Long three;
   }


### PR DESCRIPTION
> // TODO what if both are empty?

Gave this a try via `dagger-compiler` by doing this:
1. In `@Component BindsProvider` in integration-tests I added
`void inject(NoInjectsClass consumer);`
and a copy of `NoInjectsClass` from `ReflectiveMembersInjectorTest.emptyInjection` in this PR
2. in class `IntegrationTest` I added this:
```java
  @Test public void emptyInjection() {
    BindsProvider component = frontend.create(BindsProvider.class);
    NoInjectsClass consumer = new NoInjectsClass();
    component.inject(consumer);
    assertThat(consumer.one).isEqualTo(null);
    assertThat(consumer.two).isEqualTo(null);
    assertThat(consumer.three).isEqualTo(0);
    assertThat(consumer.count).isEqualTo(0);
  }
```

Observations:
- nothing happens if we `@Inject` nothing
- Dagger doesn't barf on it, just ignores
- also tried with an empty class, same result

For
```java
@Component {
  void inject(NoInjectsClass consumer);
  void inject(EmptyClass consumer);
```
the generated code is
```java
@Override public void inject(NoInjectsClass consumer) {}
@Override public void inject(EmptyClass consumer) {}
```