### PR TITLE
[dagger-reflect] Methods with @Inject may not be abstract

### DIFF
--- a/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
+++ b/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
@@ -31,8 +31,6 @@ import static dagger.reflect.Reflection.trySet;
 
 final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
   static <T> MembersInjector<T> create(Class<T> cls, BindingGraph graph) {
-    // TODO throw if interface?
-
     Map<Field, Binding<?>> fieldBindings = new LinkedHashMap<>();
     Map<Method, Binding<?>[]> methodBindings = new LinkedHashMap<>();
 
@@ -63,6 +61,10 @@ final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
         }
         if ((method.getModifiers() & Modifier.STATIC) != 0) {
           throw new IllegalArgumentException(); // TODO report can't be static
+        }
+        if ((method.getModifiers() & Modifier.ABSTRACT) != 0) {
+          throw new IllegalArgumentException("Methods with @Inject may not be abstract: "
+              + target.getCanonicalName() + "." + method.getName() + "()");
         }
 
         Type[] parameterTypes = method.getGenericParameterTypes();

--- a/dagger-reflect/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
+++ b/dagger-reflect/reflect/src/test/java/dagger/reflect/ReflectiveMembersInjectorTest.java
@@ -249,4 +249,38 @@ public final class ReflectiveMembersInjectorTest {
     assertThat(instance.baseCalled).isTrue();
     assertThat(instance.subtypeCalled).isTrue();
   }
+
+  private static interface Interface {
+    // [dagger-compile] Methods with @Inject may not be abstract
+    @Inject void interfaceMethod(String one);
+  }
+
+  @Test public void interfaceInjectionFails() {
+    BindingGraph graph = new BindingGraph.Builder().build();
+    try {
+      ReflectiveMembersInjector.create(Interface.class, graph);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().startsWith("Methods with @Inject may not be abstract");
+      assertThat(e).hasMessageThat().contains(Interface.class.getCanonicalName());
+      assertThat(e).hasMessageThat().contains("interfaceMethod");
+    }
+  }
+
+  private static abstract class Abstract {
+    // [dagger-compile] Methods with @Inject may not be abstract
+    @Inject abstract void abstractMethod(String one);
+  }
+
+  @Test public void abstractInjectionFails() {
+    BindingGraph graph = new BindingGraph.Builder().build();
+    try {
+      ReflectiveMembersInjector.create(Abstract.class, graph);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessageThat().startsWith("Methods with @Inject may not be abstract");
+      assertThat(e).hasMessageThat().contains(Abstract.class.getCanonicalName());
+      assertThat(e).hasMessageThat().contains("abstractMethod");
+    }
+  }
 }


### PR DESCRIPTION
Took the same approach as in https://github.com/JakeWharton/SdkSearch/pull/141

```diff
@Component BindsProvider {
+ void inject(Injectable consumer);
}

+interface Injectable {
+ @Inject void setter(CharSequence s);
+}
```
<details><summary>Didn't get to run test due to compile error, but same test would work before this PR with dagger-reflect. [click to expand test]</summary><p>

```java
@Test public void interfaceInjection() {
  BindsProvider component = frontend.create(BindsProvider.class);
  class Consumer implements Injectable {
    CharSequence result;
    @Override public void setter(CharSequence s) {
      this.result = s;
    }
  }
  Consumer consumer = new Consumer();
  component.inject(consumer);
  assertThat(consumer.result).isSameAs(component.string());
}
```

</p></details>

---

This time it failed with errors:
```
> Task :dagger-reflect:integration-tests:compileJava FAILED
BindsProvider.java:27: error: Methods with @Inject may not be abstract
  @Inject void setter(CharSequence s);
               ^
BindsProvider.java:10: error: [Dagger/MissingBinding] com.example.Injectable cannot be provided without an @Provides-annotated method.
interface BindsProvider {
^
      com.example.Injectable is injected at
          com.example.BindsProvider.inject(com.example.Injectable)
2 errors
```

An edge case I thought of is this:
```java
  abstract class AbstractBase {
    @Inject abstract void one(String one);
  }

  class AbstractImplemetingSubType {
    boolean subtypeCalled;
    @Inject void one(String one) {
      subtypeCalled = true;
    }
  }
```
but it fails with the same error, and removing `@Inject` from the base class works as expected.


<details><summary>
Note: I don't see any reason why interfaces are not allowed here though, the generated code would look exactly the same with the above interface. Should we raise an issue in <code>google/dagger</code>? [click to expand generated code]
</summary>
<p>

```java
public final class DaggerBindsProvider implements BindsProvider {
  @Override
  public void inject(Injectable consumer) {
    injectInjectable(consumer);}

  private Injectable injectInjectable(Injectable instance) {
    Injectable_MembersInjector.injectSetter(instance, BindsProvider_Module1_StringFactory.proxyString());
    return instance;
  }
}

public final class Injectable_MembersInjector implements MembersInjector<Injectable> {
  private final Provider<CharSequence> sProvider;

  public Injectable_MembersInjector(Provider<CharSequence> sProvider) {
    this.sProvider = sProvider;
  }

  public static MembersInjector<Injectable> create(Provider<CharSequence> sProvider) {
    return new Injectable_MembersInjector(sProvider);}

  @Override
  public void injectMembers(Injectable instance) {
    injectSetter(instance, sProvider.get());
  }

  public static void injectSetter(Object instance, CharSequence s) {
    ((Injectable) instance).setter(s);}
}
```

</p>
</details>