### PR TITLE
[dagger-reflect] Add support for ordered @Inject in class hierarchies

### DIFF
--- a/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
+++ b/dagger-reflect/reflect/src/main/java/dagger/reflect/ReflectiveMembersInjector.java
@@ -21,7 +21,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 
@@ -33,11 +36,11 @@ final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
   static <T> MembersInjector<T> create(Class<T> cls, BindingGraph graph) {
     // TODO throw if interface?
 
-    Map<Field, Binding<?>> fieldBindings = new LinkedHashMap<>();
-    Map<Method, Binding<?>[]> methodBindings = new LinkedHashMap<>();
-
+    List<Bindings> hierarchyBindings = new LinkedList<>();
     Class<?> target = cls;
     while (target != Object.class) {
+      Map<Field, Binding<?>> fieldBindings = new LinkedHashMap<>();
+      Map<Method, Binding<?>[]> methodBindings = new LinkedHashMap<>();
       for (Field field : target.getDeclaredFields()) {
         if (field.getAnnotation(Inject.class) == null) {
           continue;
@@ -75,35 +78,55 @@ final class ReflectiveMembersInjector<T> implements MembersInjector<T> {
 
         methodBindings.put(method, bindings);
       }
+      hierarchyBindings.add(new Bindings(fieldBindings, methodBindings));
 
       target = target.getSuperclass();
     }
+    // [@Inject] Fields and methods in superclasses are injected before those in subclasses.
+    // we were walking up (getSuperclass), but spec says @Inject should be walking down the hierarchy
+    Collections.reverse(hierarchyBindings);
 
     // TODO what if both are empty?
-    return new ReflectiveMembersInjector<>(fieldBindings, methodBindings);
+    return new ReflectiveMembersInjector<>(hierarchyBindings);
   }
 
-  private final Map<Field, Binding<?>> fieldBindings;
-  private final Map<Method, Binding<?>[]> methodBindings;
+  private final List<Bindings> classHierarchyBindings;
 
-  private ReflectiveMembersInjector(
-      Map<Field, Binding<?>> fieldBindings,
-      Map<Method, Binding<?>[]> methodBindings) {
-    this.fieldBindings = fieldBindings;
-    this.methodBindings = methodBindings;
+  private ReflectiveMembersInjector(List<Bindings> classHierarchyBindings) {
+    this.classHierarchyBindings = classHierarchyBindings;
   }
 
   @Override public void injectMembers(T instance) {
-    for (Map.Entry<Field, Binding<?>> fieldBinding : fieldBindings.entrySet()) {
+    for (Bindings classBinding : classHierarchyBindings) {
+      injectClassMembers(classBinding, instance);
+    }
+  }
+
+  private void injectClassMembers(Bindings classBinding, T instance) {
+    // [@Inject] Constructors are injected first, followed by fields, and then methods.
+    // Note: the constructor injection is in dagger.reflect.Binding.UnlinkedJustInTime.dependencies
+    for (Map.Entry<Field, Binding<?>> fieldBinding : classBinding.fieldBindings.entrySet()) {
       trySet(instance, fieldBinding.getKey(), fieldBinding.getValue().get());
     }
-    for (Map.Entry<Method, Binding<?>[]> methodBinding : methodBindings.entrySet()) {
+    for (Map.Entry<Method, Binding<?>[]> methodBinding : classBinding.methodBindings.entrySet()) {
       Binding<?>[] bindings = methodBinding.getValue();
       Object[] arguments = new Object[bindings.length];
       for (int i = 0; i < bindings.length; i++) {
         arguments[i] = bindings[i].get();
       }
       tryInvoke(instance, methodBinding.getKey(), arguments);
+    }
+  }
+
+  private static class Bindings {
+    final Map<Field, Binding<?>> fieldBindings;
+    final Map<Method, Binding<?>[]> methodBindings;
+
+    Bindings(
+        Map<Field, Binding<?>> fieldBindings,
+        Map<Method, Binding<?>[]> methodBindings) {
+      this.fieldBindings = fieldBindings;
+      this.methodBindings = methodBindings;
     }
   }
 }


### PR DESCRIPTION
While reading the test for `FieldsBeforeMethods` I noticed that it doesn't test what it says it's testing (note the added `this.`). Then I went and read `@Inject` JavaDoc and noticed:
> Constructors are injected first, followed by fields, and then methods.
> Fields and methods in superclasses are injected before those in subclasses.

Wrote a comprehensive test and then changed the implementation to adhere to this order.

<details><summary>The corresponding dagger-compile generated code looks like this</summary><p>

```java
public final class ReflectiveMembersInjectorTest_InjectionOrder_MembersInjector implements MembersInjector<ReflectiveMembersInjectorTest.InjectionOrder> {
  private final Provider<String> baseFieldAndSubFieldAndBaseParamAndSubParamProvider;

  public ReflectiveMembersInjectorTest_InjectionOrder_MembersInjector(
      Provider<String> baseFieldAndSubFieldAndBaseParamAndSubParamProvider) {
    this.baseFieldAndSubFieldAndBaseParamAndSubParamProvider = baseFieldAndSubFieldAndBaseParamAndSubParamProvider;
  }

  public static MembersInjector<ReflectiveMembersInjectorTest.InjectionOrder> create(
      Provider<String> baseFieldAndSubFieldAndBaseParamAndSubParamProvider) {
    return new ReflectiveMembersInjectorTest_InjectionOrder_MembersInjector(baseFieldAndSubFieldAndBaseParamAndSubParamProvider);}

  @Override
  public void injectMembers(ReflectiveMembersInjectorTest.InjectionOrder instance) {
    ReflectiveMembersInjectorTest_InjectionOrderBase_MembersInjector.injectBaseField(instance, baseFieldAndSubFieldAndBaseParamAndSubParamProvider.get());
    ReflectiveMembersInjectorTest_InjectionOrderBase_MembersInjector.injectBaseMethod(instance, baseFieldAndSubFieldAndBaseParamAndSubParamProvider.get());
    injectSubField(instance, baseFieldAndSubFieldAndBaseParamAndSubParamProvider.get());
    injectSubMethod(instance, baseFieldAndSubFieldAndBaseParamAndSubParamProvider.get());
  }

  public static void injectSubField(Object instance, String subField) {
    ((ReflectiveMembersInjectorTest.InjectionOrder) instance).subField = subField;}

  public static void injectSubMethod(Object instance, String subParam) {
    ((ReflectiveMembersInjectorTest.InjectionOrder) instance).subMethod(subParam);}
}
```

</p></details>