### PR TITLE
Check for target element on all mutations

### DIFF
--- a/frontend/chrome-extension/content/src/main/kotlin/com/jakewharton/sdksearch/content/Content.kt
+++ b/frontend/chrome-extension/content/src/main/kotlin/com/jakewharton/sdksearch/content/Content.kt
@@ -8,10 +8,11 @@ import com.jakewharton.sdksearch.store.config.StorageAreaConfigStore
 import com.jakewharton.sdksearch.store.config.PRODUCTION_DAC
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.w3c.dom.MutationObserver
+import org.w3c.dom.MutationObserverInit
 import timber.log.ConsoleTree
 import timber.log.Timber
 import timber.log.debug
-import timber.log.warn
 import kotlin.browser.document
 import kotlin.browser.window
 
@@ -30,23 +31,28 @@ fun main() {
       return@launch
     }
 
-    val targetElement = document.querySelector("#api-info-block .api-level")
-    if (targetElement != null) {
-      val br = document.createElement("br")
-      targetElement.appendChild(br)
+    val observer = MutationObserver { _, self ->
+      val targetElement = document.querySelector("#api-info-block .api-level")
+      if (targetElement != null) {
+        self.disconnect() // Only append link once.
 
-      val link = document.createElement("a")
-      link.setAttribute("href", sourceUrl)
-      link.textContent = "view source"
+        val br = document.createElement("br")
+        targetElement.appendChild(br)
 
-      val manifest = Chrome.runtime.getManifest()
-      if ("Debug" in manifest["name"].unsafeCast<String>()) {
-        link.textContent += " (debug)"
+        val link = document.createElement("a")
+        link.setAttribute("href", sourceUrl)
+        link.textContent = "view source"
+
+        val manifest = Chrome.runtime.getManifest()
+        if ("Debug" in manifest["name"].unsafeCast<String>()) {
+          link.textContent += " (debug)"
+        }
+
+        targetElement.appendChild(link)
+      } else {
+        Timber.debug { "Could not find on-page element to add 'view source' link" }
       }
-
-      targetElement.appendChild(link)
-    } else {
-      Timber.warn { "Could not find on-page element to add 'view source' link" }
     }
+    observer.observe(document, MutationObserverInit(childList = true, subtree = true))
   }
 }


### PR DESCRIPTION
DAC now loads content asynchronously so on DOM ready the target element might not actually be there yet.

Closes #162 