### PR TITLE
Enable R8 optimization

### DIFF
--- a/frontend/android/src/main/shrinker-rules.pro
+++ b/frontend/android/src/main/shrinker-rules.pro
@@ -1,9 +1,6 @@
 -dontobfuscate
 -verbose
 
-# TODO remove after figuring out what R8 bugs are blocking this from working.
--dontoptimize
-
 # Keep annotations with RUNTIME retention and their defaults.
 -keepattributes RuntimeVisible*Annotations, AnnotationDefault
 
@@ -35,18 +32,3 @@
 -keepclassmembers class <1>.<2> {
   <1>.<2>$Companion Companion;
 }
-
-# TODO This only applies when -dontoptimze is remmoved.
-# R8 in full mode sees only a single subtype of this interface. As a result, it rewrites all
-# references to use that subtype and removes this interface. This breaks the ServiceLoader because
-# the META-INF/services/ filename does not get updated.
-# TODO Remove after https://issuetracker.google.com/issues/124181030 is fixed.
-# TODO determine if the -keepnames for this interface should have prevented.
--keep class kotlinx.coroutines.internal.MainDispatcherFactory {}
-
-# TODO This only applies when -dontoptimze is remmoved.
-# R8 in full mode sees only a single subtype of this interface. As a result, it rewrites all
-# references to use that subtype and removes this interface. This breaks the Retrofit Converter for
-# Kotlin coroutines because it doesn't handle CompletableDeferred.
-# TODO Can we automate this rule https://github.com/square/retrofit/issues/3005?
--keep class kotlinx.coroutines.Deferred {}


### PR DESCRIPTION
Whatever bugs were previously blocking this seem to have been resolved.

```
OLD: sdk-search-release-dont-optimize.apk (signature: V2)
NEW: sdk-search-release-optimize.apk (signature: V2)

          │             compressed             │            uncompressed
          ├───────────┬───────────┬────────────┼───────────┬───────────┬────────────
 APK      │ old       │ new       │ diff       │ old       │ new       │ diff
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼────────────
      dex │ 834.6 KiB │ 650.9 KiB │ -183.7 KiB │   1.8 MiB │   1.4 MiB │ -411.5 KiB
     arsc │ 201.7 KiB │ 201.7 KiB │        0 B │ 201.6 KiB │ 201.6 KiB │        0 B
 manifest │   1.4 KiB │   1.4 KiB │        0 B │   4.2 KiB │   4.2 KiB │        0 B
      res │ 414.5 KiB │ 409.1 KiB │   -5.4 KiB │ 488.3 KiB │ 478.2 KiB │    -10 KiB
    asset │       0 B │       0 B │        0 B │       0 B │       0 B │        0 B
    other │  37.1 KiB │  37.1 KiB │       +4 B │  36.3 KiB │  36.3 KiB │        0 B
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼────────────
    total │   1.5 MiB │   1.3 MiB │ -189.1 KiB │   2.5 MiB │   2.1 MiB │ -421.5 KiB

 DEX     │ old   │ new   │ diff
─────────┼───────┼───────┼────────────────────
   count │     1 │     1 │     0
 strings │ 17124 │ 13476 │ -3648 (+71 -3719)
   types │  2657 │  2158 │  -499 (+17 -516)
 classes │  1903 │  1485 │  -418 (+14 -432)
 methods │ 14370 │ 10433 │ -3937 (+366 -4303)
  fields │  5326 │  4331 │  -995 (+107 -1102)

 ARSC    │ old  │ new  │ diff
─────────┼──────┼──────┼──────
 configs │   51 │   51 │  0
 entries │ 1950 │ 1950 │  0
```