### PR TITLE
Load Kotlin docs, add CL and Compose

### DIFF
--- a/backend/dac-proxy/model/src/commonMain/kotlin/com/jakewharton/sdksearch/proxy/model/DocumentedType.kt
+++ b/backend/dac-proxy/model/src/commonMain/kotlin/com/jakewharton/sdksearch/proxy/model/DocumentedType.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 data class DocumentedType(
   val packageName: String,
   val className: String,
-  val api: Int,
   val deprecated: Boolean,
   val link: String
 )

--- a/backend/dac-proxy/src/functionalTest/java/com/jakewharton/sdksearch/proxy/FunctionalTest.kt
+++ b/backend/dac-proxy/src/functionalTest/java/com/jakewharton/sdksearch/proxy/FunctionalTest.kt
@@ -6,10 +6,73 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class FunctionalTest {
-  @Test fun run() = runBlocking {
+  @Test fun platformType() = runBlocking {
     val documentedTypes = listDocumentedTypes()
     val actual = documentedTypes.single { it.className == "View" }
-    val expected = DocumentedType("android.view", "View", 1, false, "https://developer.android.com/reference/android/view/View.html")
+    val expected = DocumentedType("android.view", "View", false, "https://developer.android.com/reference/kotlin/android/view/View")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun androidxType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "AppCompatButton" }
+    val expected = DocumentedType("androidx.appcompat.widget", "AppCompatButton", false, "https://developer.android.com/reference/kotlin/androidx/appcompat/widget/AppCompatButton")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun androidxKotlinType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "BenchmarkState" }
+    val expected = DocumentedType("androidx.benchmark", "BenchmarkState", false, "https://developer.android.com/reference/kotlin/androidx/benchmark/BenchmarkState")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun androidxComposeType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "Composable" }
+    val expected = DocumentedType("androidx.compose", "Composable", false, "https://developer.android.com/reference/kotlin/androidx/compose/Composable.html")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun androidxTestType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "SdkSuppress" }
+    val expected = DocumentedType("androidx.test.filters", "SdkSuppress", false, "https://developer.android.com/reference/androidx/test/filters/SdkSuppress")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun androidxConstraintLayoutType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "ConstraintLayout" }
+    val expected = DocumentedType("androidx.constraintlayout.widget", "ConstraintLayout", false, "https://developer.android.com/reference/androidx/constraintlayout/widget/ConstraintLayout")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun materialType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "AppBarLayout" }
+    val expected = DocumentedType("com.google.android.material.appbar", "AppBarLayout", false, "https://developer.android.com/reference/com/google/android/material/appbar/AppBarLayout")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun playBillingType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "BillingClient" }
+    val expected = DocumentedType("com.android.billingclient.api", "BillingClient", false, "https://developer.android.com/reference/com/android/billingclient/api/BillingClient")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun playCoreType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "SplitInstallHelper" }
+    val expected = DocumentedType("com.google.android.play.core.splitinstall", "SplitInstallHelper", false, "https://developer.android.com/reference/com/google/android/play/core/splitinstall/SplitInstallHelper.html")
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun playInstallReferrerType() = runBlocking {
+    val documentedTypes = listDocumentedTypes()
+    val actual = documentedTypes.single { it.className == "ReferrerDetails" }
+    val expected = DocumentedType("com.android.installreferrer.api", "ReferrerDetails", false, "https://developer.android.com/reference/com/android/installreferrer/api/ReferrerDetails")
     assertThat(actual).isEqualTo(expected)
   }
 }

--- a/backend/dac-proxy/src/main/java/com/jakewharton/sdksearch/proxy/dac.kt
+++ b/backend/dac-proxy/src/main/java/com/jakewharton/sdksearch/proxy/dac.kt
@@ -16,9 +16,11 @@ import org.slf4j.LoggerFactory
 
 private val dac = "https://developer.android.com"
 private val urls = listOf(
-    "$dac/reference/classes?partial=1",
-    "$dac/reference/androidx/classes?partial=1",
+    "$dac/reference/kotlin/classes?partial=1",
+    "$dac/reference/kotlin/androidx/classes?partial=1",
+    "$dac/reference/kotlin/androidx/ui/classes?partial=1",
     "$dac/reference/androidx/test/classes?partial=1",
+    "$dac/reference/androidx/constraintlayout/classes?partial=1",
     "$dac/reference/com/google/android/material/classes?partial=1",
     "$dac/reference/com/google/android/play/core/classes?partial=1",
     "$dac/reference/com/android/billingclient/classes?partial=1",
@@ -62,17 +64,20 @@ private suspend fun listTypes(url: String): List<DocumentedType> {
   val documentedTypes = elements.map { element ->
     val linkElement = element.selectFirst("a")
 
-    val api = element.attr("data-version-added").toIntOrNull() ?: 0
     val deprecated = element.hasAttr("data-version-deprecated")
     val link = linkElement.attr("href")
+        .removePrefix(dac) // Compose links include the base URL.
     val className = linkElement.text()
 
     // Parse the package name from the URL paths.
-    val packageName = link.removePrefix("/reference/")
-        .removeSuffix("/$className.html")
+    val packageName = link
+        .removePrefix("/reference/kotlin/")
+        .removePrefix("/reference/")
+        .removeSuffix(".html")
+        .removeSuffix("/$className")
         .replace('/', '.')
 
-    DocumentedType(packageName, className, api, deprecated, "$dac$link")
+    DocumentedType(packageName, className, deprecated, "$dac$link")
   }
 
   return documentedTypes


### PR DESCRIPTION
The Kotlin versions of class lists contains types from Kotlin-only libraries. Added missing ConstraintLayout and Compose lists

Closes #179.