### PR TITLE
Update projectDependencyGraph to support AGP 4.1

### DIFF
--- a/gradle/projectDependencyGraph.gradle
+++ b/gradle/projectDependencyGraph.gradle
@@ -47,13 +47,15 @@ task projectDependencyGraph {
                 .withType(ProjectDependency)
                 .collect { it.dependencyProject }
                 .each { dependency ->
-          projects.add(project)
-          projects.add(dependency)
-          rootProjects.remove(dependency)
+          if (!(config.name.toLowerCase().contains('androidtest') || config.name.toLowerCase().contains('unittest'))) {
+              projects.add(project)
+              projects.add(dependency)
+              rootProjects.remove(dependency)
 
-          def graphKey = new Tuple2<Project, Project>(project, dependency)
-          def traits = dependencies.computeIfAbsent(graphKey) { new ArrayList<String>() }
-
+              def graphKey = new Tuple2<Project, Project>(project, dependency)
+              def traits = dependencies.computeIfAbsent(graphKey) { new ArrayList<String>() }
+          }
+          
           if (config.name.toLowerCase().endsWith('implementation')) {
             traits.add('style=dotted')
           }


### PR DESCRIPTION
AGP 4.1 https://developer.android.com/studio/releases/gradle-plugin?hl=de#library-unit-tests will make every dependency depend on itself which isn't desired.